### PR TITLE
fix: resolve grade 1 room view showing 0/0 by using overlapping check…

### DIFF
--- a/src/main/kotlin/com/b/beep/domain/attendance/domain/CheckpointResolver.kt
+++ b/src/main/kotlin/com/b/beep/domain/attendance/domain/CheckpointResolver.kt
@@ -21,6 +21,7 @@ class CheckpointResolver(
     fun getCurrentCheckpointOrNull(): AttendanceCheckpointEntity? {
         val now = LocalTime.now(ZoneId.of("Asia/Seoul"))
         val checkpoints = checkpointRepository.findAllByIsDeletedFalse()
+            .filter { it.grade == null && it.dayOfWeek == null }
 
         for (checkpoint in checkpoints) {
             if (!now.isBefore(checkpoint.startAt) && now.isBefore(checkpoint.endAt)) {
@@ -35,6 +36,7 @@ class CheckpointResolver(
 
         val now = LocalTime.now(ZoneId.of("Asia/Seoul"))
         val checkpoints = checkpointRepository.findAllByIsDeletedFalseOrderByStartAtAsc()
+            .filter { it.grade == null && it.dayOfWeek == null }
         if (checkpoints.isEmpty()) throw CustomException(AttendanceError.TIME_UNAVAILABLE)
 
         val first = checkpoints.first()

--- a/src/main/kotlin/com/b/beep/domain/attendance/repository/AttendanceQueryRepository.kt
+++ b/src/main/kotlin/com/b/beep/domain/attendance/repository/AttendanceQueryRepository.kt
@@ -4,6 +4,7 @@ import com.b.beep.domain.attendance.domain.CheckpointResolver
 import com.b.beep.domain.attendance.domain.entity.AttendanceTypeEntity
 import com.b.beep.domain.attendance.domain.entity.QAttendanceEntity
 import com.b.beep.domain.checkpoint.domain.entity.AttendanceCheckpointEntity
+import com.b.beep.domain.checkpoint.repository.AttendanceCheckpointRepository
 import com.b.beep.domain.room.domain.entity.RoomEntity
 import com.b.beep.domain.user.domain.entity.QStudentInfoEntity
 import com.b.beep.domain.user.domain.entity.QStudentScheduleEntity
@@ -22,6 +23,7 @@ class AttendanceQueryRepository(
     private val attendanceRepository: AttendanceRepository,
     private val checkpointResolver: CheckpointResolver,
     private val queryFactory: JPAQueryFactory,
+    private val checkpointRepository: AttendanceCheckpointRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
     fun findCurrentStatus(user: UserEntity): AttendanceTypeEntity? {
@@ -87,7 +89,10 @@ class AttendanceQueryRepository(
             whereBuilder.and(scheduleEntity.room.id.eq(room.id))
             whereBuilder.and(scheduleEntity.dayOfWeek.eq(dayOfWeek))
             if (targetCheckpoint != null) {
-                whereBuilder.and(scheduleEntity.checkpoint.id.eq(targetCheckpoint.id))
+                val overlappingIds = checkpointRepository.findAllByIsDeletedFalse()
+                    .filter { it.startAt < targetCheckpoint.endAt && targetCheckpoint.startAt < it.endAt }
+                    .mapNotNull { it.id }
+                whereBuilder.and(scheduleEntity.checkpoint.id.`in`(overlappingIds))
             }
         }
 
@@ -105,6 +110,7 @@ class AttendanceQueryRepository(
         }
 
         return query
+            .distinct()
             .where(whereBuilder)
             .orderBy(
                 studentInfoEntity.grade.asc(),


### PR DESCRIPTION
## #️⃣연관된 이슈
#87

## 📝작업 내용

### 문제
1학년 학생이 출석 시 `getOrCreateSchedule`이 grade-specific 체크포인트("7~8교시", "9교시")로 schedule을 저장하는데, 선생님이 room 뷰 조회 시 `getCurrentCheckpointOrNearest()`가 grade-unaware하게 일반 체크포인트("8~9교시")를 반환하여 schedule join 조건이 맞지 않아 1학년 학생이 전혀 조회되지 않는 문제 (0/0)

### 변경 사항

**`CheckpointResolver`**
- `getCurrentCheckpointOrNull()`, `getCurrentCheckpointOrNearest()`에서 general 체크포인트(`grade == null && dayOfWeek == null`)만 사용하도록 변경
- 기존에는 grade-specific 체크포인트("7~8교시", "9교시")가 포함되어 선생님 뷰에서 비결정적 동작 발생

**`AttendanceQueryRepository`**
- room 필터 시 schedule join 조건을 단일 `checkpoint.id.eq()` → 시간이 겹치는 체크포인트 ID 목록 `checkpoint.id.in()`으로 변경
- "8~9교시"(16:30~18:59)와 시간이 겹치는 "7~8교시"(15:20~17:19), "9교시"(17:20~18:10)도 조건에 포함되어 1학년 학생 정상 조회
- 중복 유저 방지를 위해 `.distinct()` 추가

## 💬리뷰 요구사항(선택)